### PR TITLE
udp: fix behavior of wrong checksums

### DIFF
--- a/net/ipv4/udp.c
+++ b/net/ipv4/udp.c
@@ -1253,10 +1253,8 @@ csum_copy_err:
 		UDP_INC_STATS_USER(sock_net(sk), UDP_MIB_INERRORS, is_udplite);
 	unlock_sock_fast(sk, slow);
 
-	if (noblock)
-		return -EAGAIN;
-
-	/* starting over for a new packet */
+	/* starting over for a new packet, but check if we need to yield */
+        cond_resched();
 	msg->msg_flags &= ~MSG_TRUNC;
 	goto try_again;
 }

--- a/net/ipv6/udp.c
+++ b/net/ipv6/udp.c
@@ -454,10 +454,8 @@ csum_copy_err:
 	}
 	unlock_sock_fast(sk, slow);
 
-	if (noblock)
-		return -EAGAIN;
-
-	/* starting over for a new packet */
+	/* starting over for a new packet, but check if we need to yield */
+        cond_resched();
 	msg->msg_flags &= ~MSG_TRUNC;
 	goto try_again;
 }


### PR DESCRIPTION
We have two problems in UDP stack related to bogus checksums :

1 ) We return -EGAIN to application even if receive queue is not empty.
    This breaks applications using edge trigger epoll()

2 ) Under UDP flood, we can loop forever without yielding to other
    processes, potentially hanging the host, especially on non SMP.

This patch is an attempt to make things better.

We might in the future add extra support for rt applications
wanting to better control time spent doing a recv() in a hostile
environment. For example we could validate checksums before queuing
packets in socket receive queue.

Change-Id: Ic25820228fd735e25a850951e059bf75ae39b653
Signed-off-by: Eruc Dumazet <edumazet@google.com>
Cc: Willem de Brujin <willemb@google.com>
Signed-off-by: David S. Miller <davem@davemloft.net>